### PR TITLE
Implements paste from clipboard

### DIFF
--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -86,12 +86,9 @@ extension AppDelegate {
         let pasteboard = NSPasteboard.general;
         let file = pasteboard.data(forType: NSPasteboard.PasteboardType.fileURL)
         if file != nil {
-            let str = String(data: file!, encoding: .utf8)
-            let url = URL(string: str!)
-            let image = NSImage(contentsOf: url!)
-            if image != nil {
-                return image
-            }
+            guard let str = String(data: file!, encoding: .utf8) else { return nil }
+            guard let url = URL(string: str) else { return nil }
+            return NSImage(contentsOf: url)
         }
 
         let tiff = pasteboard.data(forType: NSPasteboard.PasteboardType.tiff)

--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -84,21 +84,19 @@ extension AppDelegate {
     
     func getPasteboardImage() -> NSImage? {
         let pasteboard = NSPasteboard.general;
-        let file = pasteboard.data(forType: NSPasteboard.PasteboardType.fileURL)
-        if file != nil {
-            guard let str = String(data: file!, encoding: .utf8) else { return nil }
-            guard let url = URL(string: str) else { return nil }
+        if let file = pasteboard.data(forType: NSPasteboard.PasteboardType.fileURL),
+           let str = String(data: file, encoding: .utf8),
+           let url = URL(string: str)
+        {
             return NSImage(contentsOf: url)
         }
 
-        let tiff = pasteboard.data(forType: NSPasteboard.PasteboardType.tiff)
-        if tiff != nil {
-            return NSImage(data: tiff!)
+        if let tiff = pasteboard.data(forType: NSPasteboard.PasteboardType.tiff) {
+            return NSImage(data: tiff)
         }
-      
-        let png = pasteboard.data(forType: NSPasteboard.PasteboardType.png)
-        if png != nil {
-            return NSImage(data: png!)
+
+        if let png = pasteboard.data(forType: NSPasteboard.PasteboardType.png) {
+            return NSImage(data: png)
         }
 
         return nil

--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -81,6 +81,42 @@ extension AppDelegate {
 		alpha += 0.1
 		viewController.imageView.alphaValue = min(alpha, 1.0)
 	}
+    
+    func getPasteboardImage() -> NSImage? {
+        let pasteboard = NSPasteboard.general;
+        let file = pasteboard.data(forType: NSPasteboard.PasteboardType.fileURL)
+        if file != nil {
+            let str = String(data: file!, encoding: .utf8)
+            let url = URL(string: str!)
+            let image = NSImage(contentsOf: url!)
+            if image != nil {
+                return image
+            }
+        }
+
+        let tiff = pasteboard.data(forType: NSPasteboard.PasteboardType.tiff)
+        if tiff != nil {
+            return NSImage(data: tiff!)
+        }
+      
+        let png = pasteboard.data(forType: NSPasteboard.PasteboardType.png)
+        if png != nil {
+            return NSImage(data: png!)
+        }
+
+        return nil
+    }
+    
+    @IBAction func paste(_ sender: AnyObject) {
+        guard let image = getPasteboardImage() else { return }
+        let rep = image.representations[0]
+        viewController.imageView.image = image
+        let size = NSMakeSize(CGFloat(rep.pixelsWide), CGFloat(rep.pixelsHigh))
+        window.resizeTo(size, animated: true)
+        viewController.sizeTextField.isHidden = false
+        viewController.placeholderTextField.isHidden = true
+
+    }
 	
 	@IBAction func toggleLockWindow(_ sender: AnyObject) {
 		let menuItem = sender as! NSMenuItem

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -119,11 +119,11 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Edit" id="dMs-cI-mzQ">
+                            <menuItem title="Edit" id="dAm-Da-fWl">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Edit" id="bib-Uj-vzu">
+                                <menu key="submenu" title="Edit" id="aeY-sH-oUd">
                                     <items>
-                                        <menuItem title="Paste" keyEquivalent="v" id="DVo-aG-piG">
+                                        <menuItem title="Paste" keyEquivalent="v" id="Wup-uR-bUt">
                                             <connections>
                                                 <action selector="paste:" target="Voe-Tx-rLC" id="mh3-X2-sMC"/>
                                             </connections>

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -119,6 +119,18 @@
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Edit" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="Paste" keyEquivalent="v" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="paste:" target="Voe-Tx-rLC" id="mh3-X2-sMC"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="View" id="H8h-7b-M4v">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="View" id="HyV-fh-RgO">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Support Mac OS X 10.10 or later.
 
 | Key | Action |
 |:--- |:---    |
-|`⌘ V`| Paste image from clipboard. |
+|`⌘ V`| Paste image or file from clipboard. |
 
 ### Scale
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An intuitive app to display transparent images on screen.
 # System requirements
 
 Support Mac OS X 10.10 or later.
- 
+
 # Features
 
 - [x] Drag and drop images
@@ -17,6 +17,12 @@ Support Mac OS X 10.10 or later.
 - [X] Aspect ratio scaling
 
 # Keyboard Shortcuts
+
+### Set image
+
+| Key | Action |
+|:--- |:---    |
+|`⌘ V`| Paste image from clipboard. |
 
 ### Scale
 


### PR DESCRIPTION
Implements https://github.com/yuhua-chen/LayerX/issues/18

Quick documentation of requirements, as I understood them:

As a user, I want to be able to take a screenshot of a mock, and paste it into LayerX to sample against my working prototype.

- When the user presses Cmd + V (paste) or selects "Paste" in the Edit menu, LayerX should switch its presented image to the clipboard contents
    - If the clipboard contains image data, it should switch to that data
    - If the clipboard contains a file URL, it should switch to the contents of that file