### PR TITLE
Adds 'keep on top' option

### DIFF
--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+    var locked = false
+    var onTop = false
 
 	weak var window: MCWIndow!
 	weak var viewController: ViewController!
@@ -84,7 +86,9 @@ extension AppDelegate {
 	
 	@IBAction func toggleLockWindow(_ sender: AnyObject) {
 		let menuItem = sender as! NSMenuItem
-		if menuItem.title == "Lock" {
+        locked = !locked
+        onTop = locked
+		if locked {
 			menuItem.title  = "Unlock"
 			window.isMovable = false
 			window.ignoresMouseEvents = true
@@ -98,6 +102,18 @@ extension AppDelegate {
 
 		viewController.lockIconImageView.isHidden = window.isMovable || isLockIconHiddenWhileLocked
 	}
+    
+    @IBAction func toggleOnTop(_ sender: AnyObject) {
+        let menuItem = sender as! NSMenuItem
+        onTop = !onTop
+        if onTop {
+            menuItem.title = "Don't keep on top"
+            window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        } else if !locked {
+            menuItem.title = "Keep on top"
+            window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.normalWindow)))
+        }
+    }
     
     @IBAction func toggleLockIconVisibility(_ sender: AnyObject) {
         let menuItem = sender as! NSMenuItem

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -211,6 +211,11 @@
                                                 <action selector="toggleLockWindow:" target="Voe-Tx-rLC" id="Mfc-bV-lDx"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Keep on top" keyEquivalent="t" id="WZF-Ql-Ptb">
+                                            <connections>
+                                                <action selector="toggleOnTop:" target="Voe-Tx-rLC" id="1mS-lL-oZG"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
                                         <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Support Mac OS X 10.10 or later.
 
 |Key|Action|
 |:---|:---|
+|`⌘ T`| Make window always on top.|
 |`⌘ L`| Lock images and make window always on top.|
 
 # Mouse events


### PR DESCRIPTION
Implements https://github.com/yuhua-chen/LayerX/issues/17

Requirement:
- Add an option that will keep the overlay on top of other windows without preventing the overlay's movement and focus