### PR TITLE
Keep window on all spaces option

### DIFF
--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -10,6 +10,7 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+	var allSpaces = false
 
 	weak var window: MCWIndow!
 	weak var viewController: ViewController!
@@ -23,6 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
 		if let window = NSApp.windows.first as? MCWIndow {
 			window.fitsWithSize(NSMakeSize(480, 320))
+			window.collectionBehavior = [.managed, .moveToActiveSpace]
 			self.window = window
 		}
 	}
@@ -129,6 +131,17 @@ extension AppDelegate {
             window.moveBy(CGPoint(x: 0, y: -1))
         }
     }
+	@IBAction func toggleAllSpaces(_ sender: AnyObject) {
+		let menuItem = sender as! NSMenuItem
+		allSpaces = !allSpaces
+		if allSpaces {
+			menuItem.title = "Keep on this space"
+			window.collectionBehavior = [.canJoinAllSpaces]
+		} else {
+			menuItem.title = "Keep on all spaces"
+			window.collectionBehavior = [.managed, .moveToActiveSpace]
+		}
+	}
 
 	override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
 		return viewController.imageView.image != nil

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -211,6 +211,11 @@
                                                 <action selector="toggleLockWindow:" target="Voe-Tx-rLC" id="Mfc-bV-lDx"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Keep on all spaces" keyEquivalent="a" id="pZ0-jf-Hps">
+                                            <connections>
+                                                <action selector="toggleAllSpaces:" target="Voe-Tx-rLC" id="N0L-4A-TpV"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
                                         <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Support Mac OS X 10.10 or later.
 
 |Key|Action|
 |:---|:---|
+|`⌘ A`| Keep window on all spaces.|
 |`⌘ L`| Lock images and make window always on top.|
 
 # Mouse events


### PR DESCRIPTION
Implements: https://github.com/yuhua-chen/LayerX/issues/11

This PR adds a menu item that, when enabled, will keep the overlay window where it is when the user switches spaces.