### PR TITLE
Resize respecting aspect ratio

### DIFF
--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+	private let defaultSize = NSMakeSize(480, 320)
+
 	var allSpaces = false
 	var locked = false
 	var onTop = false
@@ -25,7 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
 		if let window = NSApp.windows.first as? MCWIndow {
-			window.fitsWithSize(NSMakeSize(480, 320))
+			window.fitsWithSize(defaultSize)
 			window.collectionBehavior = [.managed, .moveToActiveSpace]
 			self.window = window
 		}
@@ -44,8 +46,8 @@ fileprivate enum ArrowTag: Int {
 extension AppDelegate {
 
 	@IBAction func actualSize(_ sender: AnyObject?) {
-		let image = viewController.imageView.image!
-		window.resizeTo(image.size, animated: true)
+		let size = viewController.imageView.image?.size ?? defaultSize
+		window.resizeTo(size, animated: true)
 	}
 
 	@IBAction func makeLarger(_ sender: AnyObject) {

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -140,12 +140,12 @@
                                                 <action selector="actualSize:" target="Voe-Tx-rLC" id="Rr0-Sv-VSe"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Scale Up" keyEquivalent="+" id="Ed8-Vk-OS6">
+                                        <menuItem title="Scale Up 10%" keyEquivalent="+" id="Ed8-Vk-OS6">
                                             <connections>
                                                 <action selector="makeLarger:" target="Voe-Tx-rLC" id="ldh-JS-1g5"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Scale Down" keyEquivalent="-" id="trE-Hj-Y6i">
+                                        <menuItem title="Scale Down 10%" keyEquivalent="-" id="trE-Hj-Y6i">
                                             <connections>
                                                 <action selector="makeSmaller:" target="Voe-Tx-rLC" id="gWX-vc-gSr"/>
                                             </connections>


### PR DESCRIPTION
Addresses #13 and #23

Changes made:
- Resize up/down (including 1pt resize) are not performed with respect to image aspect ratio
- Resize up/down now resizes relative to original image size, adding/subtracting 10% of image width to window width
- Renamed menu items adding 10% to the title, just to make it clearer
- Fixed crash when attempting to restore original size (⌘ + 0) with no image set