### PR TITLE
Show and switch between multiple images

### DIFF
--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -48,7 +48,7 @@ extension AppDelegate {
 		viewController.imageSize ?? defaultSize
 	}
 
-	private func resizeAspectFit(calculator: (_ original: CGFloat, _ current: CGFloat) -> CGFloat) {
+	func resizeAspectFit(calculator: (_ original: CGFloat, _ current: CGFloat) -> CGFloat) {
 		let originalSize = self.originalSize
 		let width = calculator(originalSize.width, window.frame.size.width)
 		let height = width / originalSize.width * originalSize.height
@@ -108,12 +108,7 @@ extension AppDelegate {
 
 	@IBAction func paste(_ sender: AnyObject) {
 		guard let image = getPasteboardImage() else { return }
-
 		viewController.updateCurrentImage(image)
-
-		if let size = viewController.imageSize {
-			window.resizeTo(size, animated: true)
-		}
 	}
 	
 	@IBAction func toggleLockWindow(_ sender: AnyObject) {

--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -23,9 +23,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	var isLockIconHiddenWhileLocked = false {
 		didSet { viewController.lockIconImageView.isHidden = window.isMovable || isLockIconHiddenWhileLocked }
 	}
-	var isSizeHidden = false {
-		didSet { viewController.sizeTextField.isHidden = isSizeHidden }
-	}
 
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
 		if let window = NSApp.windows.first as? MCWIndow {
@@ -159,7 +156,7 @@ extension AppDelegate {
 	@IBAction func toggleSizeVisibility(_ sender: AnyObject) {
 		let menuItem = sender as! NSMenuItem
 		menuItem.state = menuItem.state == .on ? .off : .on
-		isSizeHidden = menuItem.state == .on
+		viewController.isSizeHidden = menuItem.state == .on
 	}
 
 	@IBAction func moveAround(_ sender: AnyObject) {

--- a/LayerX/AppDelegate.swift
+++ b/LayerX/AppDelegate.swift
@@ -48,7 +48,7 @@ fileprivate enum ArrowTag: Int {
 extension AppDelegate {
 
 	private var originalSize: NSSize {
-		viewController.imageView.image?.size ?? defaultSize
+		viewController.imageSize ?? defaultSize
 	}
 
 	private func resizeAspectFit(calculator: (_ original: CGFloat, _ current: CGFloat) -> CGFloat) {
@@ -82,15 +82,11 @@ extension AppDelegate {
 	}
 
 	@IBAction func increaseTransparency(_ sender: AnyObject) {
-		var alpha = viewController.imageView.alphaValue
-		alpha -= 0.1
-		viewController.imageView.alphaValue = max(alpha, 0.05)
+		viewController.changeTransparency(by: -0.1)
 	}
 
 	@IBAction func reduceTransparency(_ sender: AnyObject) {
-		var alpha = viewController.imageView.alphaValue
-		alpha += 0.1
-		viewController.imageView.alphaValue = min(alpha, 1.0)
+		viewController.changeTransparency(by: 0.1)
 	}
 	
 	func getPasteboardImage() -> NSImage? {
@@ -112,16 +108,15 @@ extension AppDelegate {
 
 		return nil
 	}
-	
+
 	@IBAction func paste(_ sender: AnyObject) {
 		guard let image = getPasteboardImage() else { return }
-		let rep = image.representations[0]
-		viewController.imageView.image = image
-		let size = NSMakeSize(CGFloat(rep.pixelsWide), CGFloat(rep.pixelsHigh))
-		window.resizeTo(size, animated: true)
-		viewController.sizeTextField.isHidden = false
-		viewController.placeholderTextField.isHidden = true
 
+		viewController.updateCurrentImage(image)
+
+		if let size = viewController.imageSize {
+			window.resizeTo(size, animated: true)
+		}
 	}
 	
 	@IBAction func toggleLockWindow(_ sender: AnyObject) {
@@ -196,10 +191,6 @@ extension AppDelegate {
 			menuItem.title = "Keep on all spaces"
 			window.collectionBehavior = [.managed, .moveToActiveSpace]
 		}
-	}
-
-	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-		return viewController.imageView.image != nil
 	}
 }
 

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -303,7 +303,7 @@
                                 <rect key="frame" x="454" y="243" width="16" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="center" title="0" drawsBackground="YES" id="Mmp-Eh-bBs">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                 </textFieldCell>
                             </textField>

--- a/LayerX/Base.lproj/Main.storyboard
+++ b/LayerX/Base.lproj/Main.storyboard
@@ -307,6 +307,14 @@
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                 </textFieldCell>
                             </textField>
+                            <textField hidden="YES" wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kNK-da-5FA">
+                                <rect key="frame" x="10" y="244" width="30" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="center" title="⌘ 1" drawsBackground="YES" id="N44-hk-hFy">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
+                                </textFieldCell>
+                            </textField>
                             <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Vs-Az-CYd">
                                 <rect key="frame" x="148" y="123" width="184" height="25"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Drop Images here." id="vTq-g5-aKV">
@@ -327,12 +335,14 @@
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="3I3-1H-JKb" secondAttribute="bottom" constant="10" id="64H-0g-nnO"/>
                             <constraint firstItem="8Vs-Az-CYd" firstAttribute="centerY" secondItem="m2S-Jp-Qdl" secondAttribute="centerY" id="6fI-na-pdX"/>
+                            <constraint firstItem="kNK-da-5FA" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="10" id="9LJ-n2-2gE"/>
                             <constraint firstItem="8Vs-Az-CYd" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="RwW-eB-OYh"/>
                             <constraint firstItem="JAT-ZL-8HB" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="10" id="WnK-c6-NWw"/>
                             <constraint firstItem="pOu-B0-2Yd" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="aC7-xh-2BR"/>
                             <constraint firstItem="pOu-B0-2Yd" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" id="lhy-17-EcM"/>
                             <constraint firstAttribute="trailing" secondItem="pOu-B0-2Yd" secondAttribute="trailing" id="qbm-Dq-jeg"/>
                             <constraint firstAttribute="bottom" secondItem="pOu-B0-2Yd" secondAttribute="bottom" id="r2U-99-hj5"/>
+                            <constraint firstItem="kNK-da-5FA" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="10" id="tUz-La-jPF"/>
                             <constraint firstAttribute="trailing" secondItem="3I3-1H-JKb" secondAttribute="trailing" constant="10" id="und-pJ-9Mz"/>
                             <constraint firstAttribute="trailing" secondItem="JAT-ZL-8HB" secondAttribute="trailing" constant="10" id="xlU-hc-l09"/>
                         </constraints>
@@ -342,6 +352,7 @@
                         <outlet property="lockIconImageView" destination="3I3-1H-JKb" id="Nka-rj-tDO"/>
                         <outlet property="placeholderTextField" destination="8Vs-Az-CYd" id="env-Po-Bb7"/>
                         <outlet property="sizeTextField" destination="JAT-ZL-8HB" id="vIP-80-PVG"/>
+                        <outlet property="tabTextField" destination="kNK-da-5FA" id="bpw-Fo-3hM"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/LayerX/ViewController.swift
+++ b/LayerX/ViewController.swift
@@ -20,8 +20,8 @@ class ViewController: NSViewController {
 	}
 
 	lazy var trackingArea: NSTrackingArea = {
-		let options: NSTrackingArea.Options = [.activeAlways, .mouseEnteredAndExited]
-		return NSTrackingArea(rect: self.view.bounds, options: options, owner: self, userInfo: nil)
+		let options: NSTrackingArea.Options = [.activeAlways, .mouseEnteredAndExited, .inVisibleRect]
+		return NSTrackingArea(rect: view.bounds, options: options, owner: self, userInfo: nil)
 	}()
 
 	deinit {

--- a/LayerX/ViewController.swift
+++ b/LayerX/ViewController.swift
@@ -89,12 +89,24 @@ class ViewController: NSViewController {
 	func selectTab(_ tab: Int) {
 		currentTab = tab
 		tabTextField.stringValue = "⌘ \(tab)"
-		showImage(tabImages[currentTab])
+
+		let image = tabImages[currentTab]
+		showImage(image)
+
+		if image != nil {
+			appDelegate().resizeAspectFit(calculator: { $1 })
+		}
 	}
 
 	func updateCurrentImage(_ image: NSImage?) {
+		let hadNoImages = tabImages.isEmpty
+
 		tabImages[currentTab] = image
 		showImage(image)
+
+		if image != nil {
+			appDelegate().resizeAspectFit(calculator: { hadNoImages ? $0 : $1 })
+		}
 	}
 
 	private func showImage(_ image: NSImage?) {
@@ -158,8 +170,6 @@ class ViewController: NSViewController {
 extension ViewController: MCDragAndDropImageViewDelegate {
 	func dragAndDropImageViewDidDrop(_ imageView: MCDragAndDropImageView) {
 		updateCurrentImage(imageView.image)
-
-		appDelegate().actualSize(nil)
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Support Mac OS X 10.10 or later.
 - [x] Keyboard Shortcuts
 - [x] Adjust transparency  
 - [x] Lock images
-- [X] Aspect ratio scaling
+- [x] Aspect ratio scaling
+- [x] Switching between multiple images
 
 # Keyboard Shortcuts
 
@@ -23,6 +24,8 @@ Support Mac OS X 10.10 or later.
 | Key | Action |
 |:--- |:---    |
 |`⌘ V`| Paste image or file from clipboard. |
+|`⌘ 1-9`| Switch between image tabs. |
+|`⌘ W`| Remove image assigned to the current tab. |
 
 ### Scale
 


### PR DESCRIPTION
Addresses #7 adding & changing the following:
- Keep multiple images in memory assigned to tabs numbered from 1 to 9
- Handle Cmd+V or Drag&Drop memorising image for the currently selected tab
- Switch between tabs with Cmd+[1-9] hotkey
- Forget assigned image with Cmd+W hotkey
- Window resizes to original image size only if a single image is manipulated, otherwise only window height changes
- Fixed NSTrackingArea not updating bounds automatically
- Fixed a couple of issue with labels incorrectly fading in/out
- Fixed barely visible size label in Dark mode

ℹ️ "Tabs" mentioned here are not conventional AppKit document/window tabs