### PR TITLE
Resize from the nearest screen edge

### DIFF
--- a/LayerX/MCWindow.swift
+++ b/LayerX/MCWindow.swift
@@ -34,8 +34,7 @@ class MCWIndow: NSWindow {
 	}
 
 	func resizeTo(_ size: NSSize, animated: Bool) {
-		var frame = self.frame
-		frame.size = size
+		let frame = self.resizeFrameTo(size)
 
 		if !animated {
 			setFrame(frame, display: true)
@@ -49,6 +48,32 @@ class MCWIndow: NSWindow {
 		animations.duration = 0.15
 		animations.start()
 	}
+
+    func resizeFrameTo(_ size: NSSize) -> NSRect {
+        var frame = self.frame
+
+        if let screen = NSScreen.main {
+            // Resize from the top, left, bottom or right depending on how close to each edge the window is
+            let fromLeft = (frame.origin.x + (frame.size.width / 2)) < (screen.frame.size.width / 2)
+            let fromBottom = (frame.origin.y + (frame.size.height / 2)) < (screen.frame.size.height / 2)
+            frame = frame.offsetBy(
+                dx: fromLeft ? 0 : frame.size.width - size.width,
+                dy: fromBottom ? 0 : frame.size.height - size.height)
+
+            // Keep on screen
+            if frame.origin.x + size.width > screen.frame.size.width {
+                frame.origin.x = screen.frame.size.width - size.width
+            }
+            if frame.origin.y + size.height > screen.frame.size.height {
+                frame.origin.y = screen.frame.size.height - size.height
+            }
+            frame = frame.offsetBy(dx: max(0, -frame.origin.x), dy: max(0, -frame.origin.y))
+        }
+
+        frame.size = size
+
+        return frame
+    }
 
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
         return frameRect


### PR DESCRIPTION
The app currently resizes based on the bottom-left corner of its window, expanding or contracting the top and right sides of its window. This PR changes it to resize based on the corner of the screen that the image is nearest to. So for example if it's nearest to the top right of the screen then the bottom and left sides of its window will expand or contract as the image resizes, and so on.